### PR TITLE
performance: improve memory footprint

### DIFF
--- a/src/main/java/Application/TaquinController.java
+++ b/src/main/java/Application/TaquinController.java
@@ -34,7 +34,10 @@ public class TaquinController implements Initializable {
 
     @FXML
     private ComboBox<String> heuristicCombo;
+    @FXML
+    private ComboBox<String> logCombo;
     private String chosenHeuristic = "";
+    private boolean withLogs = false;
 
     private void updateBoard() {
         for (int x = 0; x < this.board.getSize(); x++) {
@@ -83,6 +86,9 @@ public class TaquinController implements Initializable {
         this.heuristicCombo.getSelectionModel().selectedItemProperty().addListener(
                 (observableValue, s, newValue) -> chosenHeuristic = newValue
         );
+        this.logCombo.getSelectionModel().selectedItemProperty().addListener(
+                (observableValue, s, newValue) -> withLogs = !newValue.equals("No")
+        );
 
         this.updateBoard();
     }
@@ -102,6 +108,9 @@ public class TaquinController implements Initializable {
 
     @FXML
     private void onSolveClick() {
+        System.out.println("Solving:");
+        System.out.println(board.getBoardState().toString());
+
         var heuristic = switch (chosenHeuristic) {
             case "Manhattan Distance" ->
                     new ManhattanDistanceHeuristic(new TargetBoardState(Integer.parseInt(this.sizeField.getText())));
@@ -110,7 +119,11 @@ public class TaquinController implements Initializable {
             default -> new UniformCostHeuristic();
         };
 
-        var solution = board.solve(new AStar(heuristic, new DefaultCellFactory()));
+        var solution = board.solve(new AStar(heuristic, new DefaultCellFactory(), withLogs));
+        if (solution.isEmpty()) {
+            System.out.println("Failed to find solution");
+            return;
+        }
         for (var step : solution) {
             System.out.println("Instruction: " + step.instruction());
         }

--- a/src/main/java/Game/Board/DefaultBoardState.java
+++ b/src/main/java/Game/Board/DefaultBoardState.java
@@ -4,38 +4,35 @@ import Game.Cell.CellFactory;
 import Game.Cell.Position;
 import Game.Cell.TaquinCell;
 
-import java.util.ArrayList;
-import java.util.Objects;
+import java.util.Arrays;
 
 public class DefaultBoardState extends TaquinBoardState {
 
     private final int size;
 
-    private final ArrayList<ArrayList<TaquinCell>> boardImplementation = new ArrayList<>();
+    private final TaquinCell[][] boardImplementation;
 
     public DefaultBoardState(int size) {
         this.size = size;
+        boardImplementation = new TaquinCell[size][size];
         for (int i = 0; i < size; i++) {
-            boardImplementation.add(new ArrayList<>(size));
             for (int j = 0; j < size; j++) {
                 // This ensures that we can set cells to specific positions when they are first inserted
-                boardImplementation.get(i).add(null);
+                boardImplementation[i][j] = null;
             }
         }
     }
 
     public DefaultBoardState(DefaultBoardState boardState, CellFactory taquinCellFactory) {
         this.size = boardState.size;
+        boardImplementation = new TaquinCell[size][size];
         for (int i = 0; i < size; i++) {
-            boardImplementation.add(new ArrayList<>(size));
             for (int j = 0; j < size; j++) {
                 var toCopy = boardState.getAtPosition(j, i);
-                boardImplementation.get(i).add(
-                        taquinCellFactory.createTaquinCell(
-                                toCopy.getCellId(),
-                                toCopy.getPosition().getX(),
-                                toCopy.getPosition().getY()
-                        )
+                boardImplementation[i][j] = taquinCellFactory.createTaquinCell(
+                        toCopy.getCellId(),
+                        toCopy.getPosition().getX(),
+                        toCopy.getPosition().getY()
                 );
             }
         }
@@ -49,12 +46,12 @@ public class DefaultBoardState extends TaquinBoardState {
     @Override
     public void addCell(TaquinCell cell) {
         Position targetPosition = cell.getPosition();
-        boardImplementation.get(targetPosition.getY()).set(targetPosition.getX(), cell);
+        boardImplementation[targetPosition.getY()][targetPosition.getX()] = cell;
     }
 
     @Override
     public TaquinCell getAtPosition(int x, int y) {
-        return boardImplementation.get(y).get(x);
+        return boardImplementation[y][x];
     }
 
     @Override
@@ -63,7 +60,7 @@ public class DefaultBoardState extends TaquinBoardState {
     }
 
     private void setAtPosition(Position position, TaquinCell target) {
-        boardImplementation.get(position.getY()).set(position.getX(), target);
+        boardImplementation[position.getY()][position.getX()] = target;
     }
 
     @Override
@@ -154,12 +151,12 @@ public class DefaultBoardState extends TaquinBoardState {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DefaultBoardState that = (DefaultBoardState) o;
-        return size == that.size && boardImplementation.equals(that.boardImplementation);
+        return size == that.size && Arrays.deepEquals(boardImplementation, that.boardImplementation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(size, boardImplementation);
+        return Arrays.deepHashCode(boardImplementation);
     }
 
     @Override

--- a/src/main/java/Game/Cell/Position.java
+++ b/src/main/java/Game/Cell/Position.java
@@ -1,7 +1,5 @@
 package Game.Cell;
 
-import java.util.Objects;
-
 public class Position {
     private int x;
     private int y;
@@ -37,6 +35,8 @@ public class Position {
 
     @Override
     public int hashCode() {
-        return Objects.hash(x, y);
+        int result = x;
+        result = 31 * result + y;
+        return result;
     }
 }

--- a/src/main/java/Game/Cell/TaquinCell.java
+++ b/src/main/java/Game/Cell/TaquinCell.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 public abstract class TaquinCell {
 
-    public static int BLANK_ID = Integer.MAX_VALUE;
+    public static int BLANK_ID = 1013;
 
     private final int id;
     private Position position;

--- a/src/main/java/Game/Solver/SolutionStep.java
+++ b/src/main/java/Game/Solver/SolutionStep.java
@@ -28,6 +28,6 @@ public record SolutionStep(TaquinBoardState state,
 
     @Override
     public int hashCode() {
-        return Objects.hash(state);
+        return state.hashCode();
     }
 }

--- a/src/main/resources/Application/hello-view.fxml
+++ b/src/main/resources/Application/hello-view.fxml
@@ -2,11 +2,9 @@
 
 
 <?import javafx.collections.FXCollections?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import java.lang.String?>
+<?import java.lang.*?>
 <TilePane xmlns:fx="http://javafx.com/fxml/1" alignment="CENTER" xmlns="http://javafx.com/javafx/19"
           fx:controller="Application.TaquinController">
     <HBox alignment="CENTER" spacing="20.0">
@@ -25,6 +23,14 @@
                         <String fx:value="Uniform Cost"/>
                         <String fx:value="Displacement"/>
                         <String fx:value="Manhattan Distance"/>
+                    </FXCollections>
+                </items>
+            </ComboBox>
+            <ComboBox fx:id="logCombo" promptText="Log Progress?">
+                <items>
+                    <FXCollections fx:factory="observableArrayList">
+                        <String fx:value="No"/>
+                        <String fx:value="Yes"/>
                     </FXCollections>
                 </items>
             </ComboBox>


### PR DESCRIPTION
I am making logging configurable, as well as trying to improve memory footprint

I am thinking if we store the hashes of board states instead of entire objects it will be much better